### PR TITLE
Fix: Trying to access array offset on value of type bool

### DIFF
--- a/src/Bidi.php
+++ b/src/Bidi.php
@@ -176,7 +176,7 @@ class Bidi
         $this->str = $str;
         $this->chrarr = $chrarr;
         $this->ordarr = $ordarr;
-        $this->forcertl = (($forcertl === false) ? false : strtoupper($forcertl[0]));
+        $this->forcertl = (is_string($forcertl) ? strtoupper($forcertl[0]) : false);
     }
 
     /**

--- a/test/BidiTest.php
+++ b/test/BidiTest.php
@@ -86,7 +86,7 @@ class BidiTest extends TestCase
             array(
                 "\n\nABC\nEFG\n\nHIJ\n\n",
                 "\n\nABC\nEFG\n\nHIJ\n\n",
-                true
+                'L'
             ),
             array(
                 json_decode('"\u202EABC\u202C"'),


### PR DESCRIPTION
With PHP 7.4.0RC1

```
PHPUnit 7.5.15 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.0RC1
Configuration: /work/GIT/tc-lib-unicode/phpunit.xml.dist
Error:         No code coverage driver is available

...............................................................  63 / 150 ( 42%)
..........................E.................................... 126 / 150 ( 84%)
........................                                        150 / 150 (100%)

Time: 49 ms, Memory: 12,00 MB

There was 1 error:

1) Test\BidiTest::testBidiStr with data set #0 ('\n\nABC\nEFG\n\nHIJ\n\n', '\n\nABC\nEFG\n\nHIJ\n\n', true)
Trying to access array offset on value of type bool

/work/GIT/tc-lib-unicode/src/Bidi.php:179
/work/GIT/tc-lib-unicode/src/Bidi.php:139
/work/GIT/tc-lib-unicode/test/BidiTest.php:79

ERRORS!
Tests: 150, Assertions: 186, Errors: 1.
```

I fixed the test to pass the proper arg, but also the check for robustness
