### PR TITLE
Moved maxlevel calculation from StepI to StepL

### DIFF
--- a/src/Bidi.php
+++ b/src/Bidi.php
@@ -17,7 +17,6 @@ namespace Com\Tecnick\Unicode;
 
 use \Com\Tecnick\Unicode\Exception as UnicodeException;
 
-use \Com\Tecnick\Unicode\Convert;
 use \Com\Tecnick\Unicode\Bidi\StepP;
 use \Com\Tecnick\Unicode\Bidi\StepX;
 use \Com\Tecnick\Unicode\Bidi\StepXten;
@@ -28,7 +27,6 @@ use \Com\Tecnick\Unicode\Bidi\Shaping;
 use \Com\Tecnick\Unicode\Bidi\StepL;
 use \Com\Tecnick\Unicode\Data\Pattern as UniPattern;
 use \Com\Tecnick\Unicode\Data\Type as UniType;
-use \Com\Tecnick\Unicode\Data\Constant as UniConstant;
 
 /**
  * Com\Tecnick\Unicode\Bidi
@@ -149,7 +147,7 @@ class Bidi
 
         $this->process();
     }
-    
+
 
     /**
      * Set Input data
@@ -243,7 +241,7 @@ class Bidi
      */
     protected function getParagraphs()
     {
-        
+
         $paragraph = array(0 => array());
         $pdx = 0; // paragraphs index
         foreach ($this->ordarr as $ord) {
@@ -282,7 +280,7 @@ class Bidi
                 }
                 $chardata = array_merge($chardata, $seq['item']);
             }
-            $stepl = new StepL($chardata, $pel, (isset($seq['maxlevel']) ? $seq['maxlevel'] : 0));
+            $stepl = new StepL($chardata, $pel);
             $chardata = $stepl->getChrData();
             foreach ($chardata as $chd) {
                 $this->bidiordarr[] = $chd['char'];

--- a/src/Bidi/StepI.php
+++ b/src/Bidi/StepI.php
@@ -33,7 +33,6 @@ class StepI extends \Com\Tecnick\Unicode\Bidi\StepBase
      */
     protected function process()
     {
-        $this->seq['maxlevel'] = 0;
         $this->processStep('processI');
     }
 
@@ -63,7 +62,5 @@ class StepI extends \Com\Tecnick\Unicode\Bidi\StepBase
                 $this->seq['item'][$idx]['level'] += 2;
             }
         }
-        // update the maximum level
-        $this->seq['maxlevel'] = max($this->seq['maxlevel'], $this->seq['item'][$idx]['level']);
     }
 }

--- a/src/Bidi/StepL.php
+++ b/src/Bidi/StepL.php
@@ -75,7 +75,6 @@ class StepL
         $this->numchars = count($this->chardata);
         $this->pel = $pel;
         $this->processL1();
-        $this->maxlevel = $this->getMaxLevel();
         $this->processL2();
     }
 
@@ -102,6 +101,10 @@ class StepL
     {
         for ($idx = 0; $idx < $this->numchars; ++$idx) {
             $this->processL1b($idx, $idx);
+
+            if ($this->chardata[$idx]['level'] > $this->maxlevel) {
+                $this->maxlevel = $this->chardata[$idx]['level'];
+            }
         }
     }
 
@@ -160,19 +163,5 @@ class StepL
             }
             $this->chardata = $ordered;
         }
-    }
-
-    /**
-     * @return int
-     */
-    private function getMaxLevel()
-    {
-        $maxLevel = 0;
-        foreach ($this->chardata as $char) {
-            if ($char['level'] > $maxLevel) {
-                $maxlevel = $char['level'];
-            }
-        }
-        return $maxlevel;
     }
 }


### PR DESCRIPTION
StepI calculates the maxlevel, does not use it internally and forwards it to StepL. The maxlevel on the sequence isn't used later anywhere else so I removed it.
StepL::processL1 probably changes the level which could result in a decreased maxlevel,
One example for this to happen is the testdata `12 `.

I changed processL1 just because I initially wanted to calculate the maxlevel there which I refrain from because of the recursion and several unnecessary checks. I still left it in the pull request because I think it is better readable with less returns.
