### PR TITLE
Vectorize strToOrdArr / ordArrToChrArr for performance:

### DIFF
--- a/src/Convert.php
+++ b/src/Convert.php
@@ -110,10 +110,23 @@ class Convert extends \Com\Tecnick\Unicode\Convert\Encoding
      * @param array<int> $ords Array of UTF-8 code points
      *
      * @return array<string>
+     *
+     * @throws UniException
      */
     public function ordArrToChrArr(array $ords): array
     {
-        return \array_map($this->chr(...), $ords);
+        if ($ords === []) {
+            return [];
+        }
+
+        // Vectorized: pack all codepoints to UCS-4BE and convert once, instead of calling
+        // chr() (pack + mb_convert_encoding) per codepoint.
+        $str = \mb_convert_encoding(\pack('N*', ...$ords), 'UTF-8', 'UCS-4BE');
+        if ($str === false) {
+            throw new UniException('Error converting code points');
+        }
+
+        return $this->strToChrArr($str);
     }
 
     /**
@@ -127,7 +140,23 @@ class Convert extends \Com\Tecnick\Unicode\Convert\Encoding
      */
     public function strToOrdArr(string $str): array
     {
-        return $this->chrArrToOrdArr($this->strToChrArr($str));
+        if ($str === '') {
+            return [];
+        }
+
+        // Vectorized: convert the whole string to UCS-4BE (4 bytes/char) and unpack every
+        // codepoint at once, instead of splitting it and calling ord() per character.
+        $ucs = \mb_convert_encoding($str, 'UCS-4BE', 'UTF-8');
+        if ($ucs === false) {
+            throw new UniException('Error converting string');
+        }
+
+        $ords = \unpack('N*', $ucs);
+        if ($ords === false) {
+            throw new UniException('Error unpacking string');
+        }
+
+        return \array_values($ords);
     }
 
     /**


### PR DESCRIPTION
Perform one bulk conversion per string instead of a per-character array_map(ord/chr).

Solves https://github.com/tecnickcom/tc-lib-unicode/issues/10.

Heads-up, Claude pretty much analyzed and provided this performance improvement.

This eliminates Convert->ord entirely (99,875 → 0 calls), mb_convert_encoding cut 93% (138k → 9k) and has identical output.  All tests pass with `composer test` before and after.


**Micro-benchmark** (16,000 calls each, Xdebug off, output byte-identical + round-trip verified):
| method | before | after | speedup |
|---|---|---|---|
| `strToOrdArr` | 10.7 µs/call | 0.59 µs/call | **~18×** |
| `ordArrToChrArr` | 8.4 µs/call | 2.94 µs/call | **~2.85×** |

**Real-world** (Xdebug profile, 25-page text PDF, full request):
| metric | before | after |
|---|---|---|
| `Convert->ord` calls | 99,875 (8.66%, 0.42 s) | **0** (eliminated) |
| `Convert->chrArrToOrdArr` | 3,050 (1.24%) | **0** (eliminated) |
| `Convert->chr` calls | 38,626 (2.72%) | 4,926 (0.50%) |
| `array_map` calls | 5,339 (8.24%, 0.40 s) | 1,214 (0.71%) |
| `mb_convert_encoding` calls | **138,507** (1.15%) | **9,057** (0.17%) |
| Convert conversion total | ~1.12 s (~23% of request) | ~0.08 s (~2%) |
| full request | 4.89 s | **3.84 s (−21%)** |
...


## Checklist:

- [ ] The `make buildall` command has been run successfully without any error or warning.
- [ ] Any new code line is covered by unit tests and the coverage has not dropped.
- [ ] Any new code follows the style guidelines of this project.
- [X] The code changes have been self-reviewed.
- [ ] Corresponding changes to the documentation have been made.
- [ ] The version has been updated in the VERSION file.

## Type of change:
Performance.